### PR TITLE
Docs: v0.7.3

### DIFF
--- a/sample_specs/reqres-in-v0.7.3/Env.chk
+++ b/sample_specs/reqres-in-v0.7.3/Env.chk
@@ -1,0 +1,4 @@
+version: default:variable:0.7.2
+
+
+server: https://reqres.in/api

--- a/sample_specs/reqres-in-v0.7.3/Env.chk
+++ b/sample_specs/reqres-in-v0.7.3/Env.chk
@@ -1,4 +1,4 @@
-version: default:variable:0.7.2
+version: default:variable:0.7.3
 
-
-server: https://reqres.in/api
+variables:
+  server: https://reqres.in/api

--- a/sample_specs/reqres-in-v0.7.3/User/UserFullSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserFullSpec.chk
@@ -1,0 +1,24 @@
+version: default:testcase:0.7.2
+
+variables:
+  ::import: [Env]
+  Id: ~
+  Resp_Req: ~
+  Resp_Spec: ~
+
+request:
+  path: "{$Env.server}/user/{$Id}"
+  method: GET
+  return: ~
+
+spec:
+  execute:
+    file: self
+    result: $Resp_Req
+    with:
+      $Id: 3
+
+  asserts:
+    - {type: AssertEquals, actual: $Resp_Req.code, expected: 200, silent: true}
+
+  return: $Resp_Spec

--- a/sample_specs/reqres-in-v0.7.3/User/UserFullSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserFullSpec.chk
@@ -9,7 +9,6 @@ variables:
 request:
   path: "{$Env.server}/user/{$Id}"
   method: GET
-  return: ~
 
 spec:
   execute:

--- a/sample_specs/reqres-in-v0.7.3/User/UserFullSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserFullSpec.chk
@@ -1,7 +1,9 @@
 version: default:testcase:0.7.3
 
 variables:
-  __import__: [Env]
+  __import__: [
+    Env: ../Env.chk
+  ]
   Id: ~
   Resp_Req: ~
   Resp_Spec: ~

--- a/sample_specs/reqres-in-v0.7.3/User/UserFullSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserFullSpec.chk
@@ -1,7 +1,7 @@
-version: default:testcase:0.7.2
+version: default:testcase:0.7.3
 
 variables:
-  ::import: [Env]
+  __import__: [Env]
   Id: ~
   Resp_Req: ~
   Resp_Spec: ~
@@ -15,10 +15,8 @@ spec:
   execute:
     file: self
     result: $Resp_Req
-    with:
-      $Id: 3
 
   asserts:
     - {type: AssertEquals, actual: $Resp_Req.code, expected: 200, silent: true}
 
-  return: $Resp_Spec
+expose: $Resp_Spec

--- a/sample_specs/reqres-in-v0.7.3/User/UserMinimalRequest.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserMinimalRequest.chk
@@ -1,0 +1,5 @@
+version: default:http:0.7.2
+
+request:
+  path: https://reqres.in/api/users/1
+  method: GET

--- a/sample_specs/reqres-in-v0.7.3/User/UserReq.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserReq.chk
@@ -1,7 +1,7 @@
-version: 'default:http:0.7.2'
+version: 'default:http:0.7.3'
 
 variables:
-  ::import: ['Vars', 'Vars2']
+  __import__: ['.Vars', '.Vars2']
   Id: 2
 
 request:

--- a/sample_specs/reqres-in-v0.7.3/User/UserReq.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserReq.chk
@@ -1,0 +1,13 @@
+version: 'default:http:0.7.2'
+
+variables:
+  ::import: ['Vars', 'Vars2']
+  Id: 2
+
+request:
+  url: '{$Vars2.server}/api/users/{$Id}'
+  method: '{$Vars.varA}'
+
+  url_params:
+    bb: '{$Vars.varB}'
+    bc: '{$Vars2.varB}'

--- a/sample_specs/reqres-in-v0.7.3/User/UserReq.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserReq.chk
@@ -1,7 +1,9 @@
 version: 'default:http:0.7.3'
 
 variables:
-  __import__: ['.Vars', '.Vars2']
+  __import__:
+    - Vars: ../Vars.chk
+    - Vars2: ../Vars2.chk
   Id: 2
 
 request:

--- a/sample_specs/reqres-in-v0.7.3/User/UserRequest.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserRequest.chk
@@ -1,0 +1,17 @@
+version: default:http:0.7.2
+
+variables:
+  ::import:
+    - Env
+    - UV: UserCreate/Vars
+
+  Id: 1
+  Response: ~
+
+# 1. too long path to include to use the veriable when file path is long
+# 2. user need to understand magic to use basic feature
+
+request:
+  path: "{$Env.server}/users/{$Id}"
+  method: $UserCreate/Vars.method
+  return: $Response

--- a/sample_specs/reqres-in-v0.7.3/User/UserRequest.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserRequest.chk
@@ -1,17 +1,13 @@
-version: default:http:0.7.2
+version: default:http:0.7.3
 
 variables:
-  ::import:
+  __import__:
     - Env
     - UV: UserCreate/Vars
 
   Id: 1
   Response: ~
 
-# 1. too long path to include to use the veriable when file path is long
-# 2. user need to understand magic to use basic feature
-
 request:
   path: "{$Env.server}/users/{$Id}"
-  method: $UserCreate/Vars.method
-  return: $Response
+  method: $UV.method

--- a/sample_specs/reqres-in-v0.7.3/User/UserRequest.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserRequest.chk
@@ -2,12 +2,11 @@ version: default:http:0.7.3
 
 variables:
   __import__:
-    - Env
-    - UV: UserCreate/Vars
+    - UV: ~/Vars.chk
 
   Id: 1
   Response: ~
 
 request:
-  path: "{$Env.server}/users/{$Id}"
+  path: "{$_ENV.server}/users/{$Id}"
   method: $UV.method

--- a/sample_specs/reqres-in-v0.7.3/User/UserSpec_Float.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserSpec_Float.chk
@@ -1,0 +1,14 @@
+version: default:testcase:0.7.2
+
+variables:
+  Response:
+
+spec:
+  execute: 
+    file: User/UserRequest.chk
+    with:
+      $Id: 3.2
+    result: $Response
+
+  asserts:
+    - {type: AssertEquals, actual: $Response.code, expected: 404}

--- a/sample_specs/reqres-in-v0.7.3/User/UserSpec_Float.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserSpec_Float.chk
@@ -1,11 +1,11 @@
 version: default:testcase:0.7.2
 
 variables:
-  Response:
+  Response: ~
 
 spec:
   execute: 
-    file: User/UserRequest.chk
+    file: .UserRequest.chk
     with:
       $Id: 3.2
     result: $Response

--- a/sample_specs/reqres-in-v0.7.3/User/UserSpec_Float.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserSpec_Float.chk
@@ -5,9 +5,9 @@ variables:
 
 spec:
   execute: 
-    file: .UserRequest.chk
+    file: ./UserRequest.chk
     with:
-      $Id: 3.2
+      Id: 3.2
     result: $Response
 
   asserts:

--- a/sample_specs/reqres-in-v0.7.3/User/UserSpec_Int.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserSpec_Int.chk
@@ -5,9 +5,9 @@ variables:
 
 spec:
   execute:
-    file: .UserRequest.chk
+    file: ./UserRequest.chk
     with:
-      $Id: 2
+      Id: 2
     result: $Response
 
   asserts:

--- a/sample_specs/reqres-in-v0.7.3/User/UserSpec_Int.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserSpec_Int.chk
@@ -1,0 +1,14 @@
+version: default:testcase:0.7.2
+
+variables:
+  Response:
+
+spec:
+  execute:
+    file: User/UserRequest.chk
+    with:
+      $Id: 2
+    result: $Response
+
+  asserts:
+    - {type: AssertEquals, actual: $Response.code, expected: 404}

--- a/sample_specs/reqres-in-v0.7.3/User/UserSpec_Int.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserSpec_Int.chk
@@ -1,11 +1,11 @@
 version: default:testcase:0.7.2
 
 variables:
-  Response:
+  Response: ~
 
 spec:
   execute:
-    file: User/UserRequest.chk
+    file: .UserRequest.chk
     with:
       $Id: 2
     result: $Response

--- a/sample_specs/reqres-in-v0.7.3/User/UserSpec_String.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserSpec_String.chk
@@ -1,0 +1,14 @@
+version: default:testcase:0.7.2
+
+variables:
+  Response:
+
+spec:
+  execute:
+    file: User/UserRequest.chk
+    with:
+      $Id: "JustStr"
+    result: $Response
+
+  asserts:
+    - {type: AssertEquals, actual: $Response.code, expected: 404}

--- a/sample_specs/reqres-in-v0.7.3/User/UserSpec_String.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserSpec_String.chk
@@ -1,11 +1,11 @@
 version: default:testcase:0.7.2
 
 variables:
-  Response:
+  Response: ~
 
 spec:
   execute:
-    file: User/UserRequest.chk
+    file: .UserRequest.chk
     with:
       $Id: "JustStr"
     result: $Response

--- a/sample_specs/reqres-in-v0.7.3/User/UserSpec_String.chk
+++ b/sample_specs/reqres-in-v0.7.3/User/UserSpec_String.chk
@@ -5,9 +5,9 @@ variables:
 
 spec:
   execute:
-    file: .UserRequest.chk
+    file: ./UserRequest.chk
     with:
-      $Id: "JustStr"
+      Id: "JustStr"
     result: $Response
 
   asserts:

--- a/sample_specs/reqres-in-v0.7.3/UserCreate/PlainRequest.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserCreate/PlainRequest.chk
@@ -1,0 +1,19 @@
+version: default:http:0.7.2
+
+variables:
+  code: ~
+  headers: ~
+
+request:
+  path: "https://reqres.in/api/users"
+  method: POST
+  body[json]: {
+    "name": "Morpheus",
+    "job": "leader"
+  }
+
+  return:
+    - .request.response.code: $code
+    - .request.response.headers: $headers
+
+expose: [$code, $headers]

--- a/sample_specs/reqres-in-v0.7.3/UserCreate/PlainRequest.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserCreate/PlainRequest.chk
@@ -1,4 +1,4 @@
-version: default:http:0.7.2
+version: default:http:0.7.3
 
 variables:
   code: ~
@@ -13,7 +13,7 @@ request:
   }
 
   return:
-    - .request.response.code: $code
-    - .request.response.headers: $headers
+    - .response.code: $code
+    - .response.headers: $headers
 
 expose: [$code, $headers]

--- a/sample_specs/reqres-in-v0.7.3/UserCreate/PlainRequest.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserCreate/PlainRequest.chk
@@ -12,8 +12,7 @@ request:
     "job": "leader"
   }
 
-  return:
-    - .response.code: $code
-    - .response.headers: $headers
+expose:
+  - .response.code
+  - .response.headers
 
-expose: [$code, $headers]

--- a/sample_specs/reqres-in-v0.7.3/UserCreate/PlainSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserCreate/PlainSpec.chk
@@ -1,4 +1,4 @@
-version: default:testcase:0.7.2
+version: default:testcase:0.7.3
 
 variables:
   Code: ~
@@ -6,8 +6,8 @@ variables:
 
 spec:
   execute:
-    file: UserCreate/PlainRequest.chk
-    result: [$Code, $Headers]
+    file: .UserCreate/PlainRequest.chk
+    result: [$Code, _]
 
   asserts:
     - {type: AssertEquals, actual: $Code, expected: 201}

--- a/sample_specs/reqres-in-v0.7.3/UserCreate/PlainSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserCreate/PlainSpec.chk
@@ -6,7 +6,7 @@ variables:
 
 spec:
   execute:
-    file: .UserCreate/PlainRequest.chk
+    file: ~/UserCreate/PlainRequest.chk
     result: [$Code, _]
 
   asserts:

--- a/sample_specs/reqres-in-v0.7.3/UserCreate/PlainSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserCreate/PlainSpec.chk
@@ -1,0 +1,13 @@
+version: default:testcase:0.7.2
+
+variables:
+  Code: ~
+  Headers: ~
+
+spec:
+  execute:
+    file: UserCreate/PlainRequest.chk
+    result: [$Code, $Headers]
+
+  asserts:
+    - {type: AssertEquals, actual: $Code, expected: 201}

--- a/sample_specs/reqres-in-v0.7.3/UserCreate/Request.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserCreate/Request.chk
@@ -14,4 +14,3 @@ request:
     'name': $Name,
     'job': $Job,
   }
-  return: .code

--- a/sample_specs/reqres-in-v0.7.3/UserCreate/Request.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserCreate/Request.chk
@@ -14,8 +14,4 @@ request:
     'name': $Name,
     'job': $Job,
   }
-  return: .body
-
-
-# why `return`?
-#   - in future I can add more operation on it
+  return: .code

--- a/sample_specs/reqres-in-v0.7.3/UserCreate/Request.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserCreate/Request.chk
@@ -1,0 +1,21 @@
+version: default:http:0.7.2
+describe: Request
+
+variables:
+  Name: 'Morpheus'
+  Job: 'leader'
+  Response: 
+  Server: https://reqres.io/api/v1
+
+request:
+  path: "{$Server}/users"
+  method: POST
+  body[json]: {
+    'name': $Name,
+    'job': $Job,
+  }
+  return: .body
+
+
+# why `return`?
+#   - in future I can add more operation on it

--- a/sample_specs/reqres-in-v0.7.3/UserCreate/Request.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserCreate/Request.chk
@@ -1,15 +1,16 @@
 version: default:http:0.7.2
-describe: Request
+describe: "Request with input"
 
 variables:
-  Name: 'Morpheus'
-  Job: 'leader'
-  Response: 
+  Name: 'Morpheus' :input:
+  Job: 'leader' :input:
+  Response: ~
   Server: https://reqres.io/api/v1
 
 request:
   path: "{$Server}/users"
   method: POST
+
   body[json]: {
     'name': $Name,
     'job': $Job,

--- a/sample_specs/reqres-in-v0.7.3/UserCreate/Spec_PassBody.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserCreate/Spec_PassBody.chk
@@ -5,7 +5,7 @@ variables:
 
 spec:
   execute:
-    file: '.Request.chk'
+    file: './Request.chk'
     result: $Response
     with:
       Name: "Neo"

--- a/sample_specs/reqres-in-v0.7.3/UserCreate/Spec_PassBody.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserCreate/Spec_PassBody.chk
@@ -1,0 +1,15 @@
+version: default:testcase:0.7.2
+
+variables:
+  Response: ~
+
+spec:
+  execute:
+    file: 'UserCreate/Request.chk'
+    result: $Response
+    with:
+      Name: "Neo"
+      Job: "choosen-one"
+
+  asserts:
+    - {type: AssertEquals, actual: $Response.code, expected: 201, silent: true}

--- a/sample_specs/reqres-in-v0.7.3/UserCreate/Spec_PassBody.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserCreate/Spec_PassBody.chk
@@ -5,7 +5,7 @@ variables:
 
 spec:
   execute:
-    file: 'UserCreate/Request.chk'
+    file: '.Request.chk'
     result: $Response
     with:
       Name: "Neo"

--- a/sample_specs/reqres-in-v0.7.3/UserDeleteSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserDeleteSpec.chk
@@ -1,11 +1,10 @@
 version: 'default:testcase:0.7.3'
 
 variables:
-  __import__: ['Env']
   Response: ~
 
 request:
-  path: "{$Env.server}/users/2"
+  path: "{$_ENV.server}/users/2"
   method: DELETE
 
 spec:

--- a/sample_specs/reqres-in-v0.7.3/UserDeleteSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserDeleteSpec.chk
@@ -1,0 +1,17 @@
+version: 'default:testcase:0.7.2'
+
+variables:
+  ::import: ['Env']
+  Response:
+
+request:
+  path: "{$Env.server}/users/2"
+  method: DELETE
+  return: ~
+
+spec:
+  execute:
+    file: self
+    result: $Response
+  asserts:
+    - {type: AssertEquals, actual: $Response.code, expected: 204}

--- a/sample_specs/reqres-in-v0.7.3/UserDeleteSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserDeleteSpec.chk
@@ -1,8 +1,8 @@
-version: 'default:testcase:0.7.2'
+version: 'default:testcase:0.7.3'
 
 variables:
-  ::import: ['Env']
-  Response:
+  __import__: ['Env']
+  Response: ~
 
 request:
   path: "{$Env.server}/users/2"

--- a/sample_specs/reqres-in-v0.7.3/UserDeleteSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserDeleteSpec.chk
@@ -7,7 +7,6 @@ variables:
 request:
   path: "{$Env.server}/users/2"
   method: DELETE
-  return: ~
 
 spec:
   execute:

--- a/sample_specs/reqres-in-v0.7.3/UserListSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserListSpec.chk
@@ -1,0 +1,17 @@
+version: 'default:testcase:0.7.2'
+
+variables: 
+  ::import: ['Env']
+  Code: ~
+
+request:
+  method: GET
+  path: "{$Env.server}/users?page=1"
+  return: .code
+
+spec:
+  execute:
+    file: self
+    result: $Code
+  asserts:
+    - {type: AssertEquals, actual: $Code, expected: 200}

--- a/sample_specs/reqres-in-v0.7.3/UserListSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserListSpec.chk
@@ -7,7 +7,6 @@ variables:
 request:
   method: GET
   path: "{$Env.server}/users?page=1"
-  return: .code
 
 spec:
   execute:

--- a/sample_specs/reqres-in-v0.7.3/UserListSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserListSpec.chk
@@ -1,12 +1,11 @@
 version: 'default:testcase:0.7.2'
 
 variables: 
-  __import__: ['Env']
   Code: ~
 
 request:
   method: GET
-  path: "{$Env.server}/users?page=1"
+  path: "{$_ENV.server}/users?page=1"
 
 spec:
   execute:

--- a/sample_specs/reqres-in-v0.7.3/UserListSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserListSpec.chk
@@ -1,7 +1,7 @@
 version: 'default:testcase:0.7.2'
 
 variables: 
-  ::import: ['Env']
+  __import__: ['Env']
   Code: ~
 
 request:

--- a/sample_specs/reqres-in-v0.7.3/UserListSpec_WithVar.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserListSpec_WithVar.chk
@@ -1,0 +1,21 @@
+version: 'default:testcase:0.7.2'
+describe: UserListSpec_WithVar {Page?}
+
+variables: 
+  __import__: ['Env']
+  Page: 1
+  Response: ~
+  Code: ~
+
+request:
+  method: GET
+  path: "{$Env.server}/users?page={$Page}"
+  return: [
+    .request.response.code: $Code,
+    .request.response.headers: $Headers
+  ]
+
+spec:
+  execute: ~
+  asserts:
+    - {type: AssertEquals, actual: .request.response.code, expected: 200}

--- a/sample_specs/reqres-in-v0.7.3/UserListSpec_WithVar.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserListSpec_WithVar.chk
@@ -9,15 +9,12 @@ variables:
 request:
   method: GET
   path: "{$Env.server}/users?page={$Page}"
-  return: [
-    .response.code: $Code,
-    .response.headers: $Headers
-  ]
 
 spec:
   execute: ~
   asserts:
-    - {type: AssertEquals, actual: $Code, expected: 200}
+    - {type: AssertEquals, actual: .response.code, expected: 200}
 
 expose: 
-  - $Headers
+  - .response.code
+  - .response.headers

--- a/sample_specs/reqres-in-v0.7.3/UserListSpec_WithVar.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserListSpec_WithVar.chk
@@ -1,8 +1,8 @@
 version: 'default:testcase:0.7.3'
-describe: UserListSpec_WithVar {Page?}
+describe: "User list spec with varriable input"
 
 variables: 
-  Page: 1
+  Page: 1 :input:
   Response: ~
   Code: ~
 

--- a/sample_specs/reqres-in-v0.7.3/UserListSpec_WithVar.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserListSpec_WithVar.chk
@@ -1,8 +1,7 @@
-version: 'default:testcase:0.7.2'
+version: 'default:testcase:0.7.3'
 describe: UserListSpec_WithVar {Page?}
 
 variables: 
-  __import__: ['Env']
   Page: 1
   Response: ~
   Code: ~
@@ -11,11 +10,14 @@ request:
   method: GET
   path: "{$Env.server}/users?page={$Page}"
   return: [
-    .request.response.code: $Code,
-    .request.response.headers: $Headers
+    .response.code: $Code,
+    .response.headers: $Headers
   ]
 
 spec:
   execute: ~
   asserts:
-    - {type: AssertEquals, actual: .request.response.code, expected: 200}
+    - {type: AssertEquals, actual: $Code, expected: 200}
+
+expose: 
+  - $Headers

--- a/sample_specs/reqres-in-v0.7.3/UserListSpec_WithVar.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserListSpec_WithVar.chk
@@ -8,7 +8,7 @@ variables:
 
 request:
   method: GET
-  path: "{$Env.server}/users?page={$Page}"
+  path: "{$_ENV.server}/users?page={$Page}"
 
 spec:
   execute: ~

--- a/sample_specs/reqres-in-v0.7.3/UserUpdatePartialRequest.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserUpdatePartialRequest.chk
@@ -9,4 +9,4 @@ request:
   body: {
     "job": "zion resident"
   }
-  return: .code
+

--- a/sample_specs/reqres-in-v0.7.3/UserUpdatePartialRequest.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserUpdatePartialRequest.chk
@@ -1,12 +1,7 @@
 version: 'default:http:0.7.2'
 
-variables: 
-  __import__: ['Env']
-
 request:
-  path: "{$Env.server}/users/2"
+  path: "{$_ENV.server}/users/2"
   method: PATCH
-  body: {
+  body:
     "job": "zion resident"
-  }
-

--- a/sample_specs/reqres-in-v0.7.3/UserUpdatePartialRequest.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserUpdatePartialRequest.chk
@@ -1,0 +1,12 @@
+version: 'default:http:0.7.2'
+
+variables: 
+  ::import: ['Env']
+
+request:
+  path: "{$Env.server}/users/2"
+  method: PATCH
+  body: {
+    "job": "zion resident"
+  }
+  return: .code

--- a/sample_specs/reqres-in-v0.7.3/UserUpdatePartialRequest.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserUpdatePartialRequest.chk
@@ -1,7 +1,7 @@
 version: 'default:http:0.7.2'
 
 variables: 
-  ::import: ['Env']
+  __import__: ['Env']
 
 request:
   path: "{$Env.server}/users/2"

--- a/sample_specs/reqres-in-v0.7.3/UserUpdatePartialSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserUpdatePartialSpec.chk
@@ -1,12 +1,12 @@
 version: 'default:testcase:0.7.2'
 
 variables:
-  Code: ~
+  code: ~
 
 spec:
   execute:
-    file: .UserUpdatePartialRequest.chk
-    result: $Code
+    file: ./UserUpdatePartialRequest.chk
+    result: $code
 
   asserts:
-    - {type: AssertEquals, actual: $Code, expected: 200}
+    - {type: AssertEquals, actual: $code, expected: 200}

--- a/sample_specs/reqres-in-v0.7.3/UserUpdatePartialSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserUpdatePartialSpec.chk
@@ -1,0 +1,12 @@
+version: 'default:testcase:0.7.2'
+
+variables:
+  Code: ~
+
+spec:
+  execute:
+    file: .UserUpdatePartialRequest.chk
+    result: $Code
+
+  asserts:
+    - {type: AssertEquals, actual: $Code, expected: 200}

--- a/sample_specs/reqres-in-v0.7.3/UserUpdateRequest_WithoutVars.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserUpdateRequest_WithoutVars.chk
@@ -1,0 +1,9 @@
+version: 'default:test-spec:0.7.2'
+
+request:
+  path: "https://reqres.in/api/users/2"
+  method: PUT
+  body: {
+    "name": "morpheus",
+    "job": "zion resident"
+  }

--- a/sample_specs/reqres-in-v0.7.3/UserUpdateSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserUpdateSpec.chk
@@ -1,25 +1,19 @@
 version: 'default:testcase:0.7.3'
 
 variables: 
-  # __import__: ['Env']
+  __import__: 
+    - Env: './Env.chk'
   Id: 2
   Body: {
     "name": "morpheus",
     "job": "zion resident"
   }
   Code: ~
-  ... :
-    - Env: .Env
 
 request:
   path: "{$Env.server}/users/{$Id}"
   method: PUT
-  body: $Body # inject Body here
-  all_include: 
-    ... :  # unpack statement
-      - $Body
-      - id: $Id
-    class: 1
+  body: $Body
 
 spec:
   asserts:

--- a/sample_specs/reqres-in-v0.7.3/UserUpdateSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserUpdateSpec.chk
@@ -1,0 +1,26 @@
+version: 'default:testcase:0.7.2'
+
+variables: 
+  ::import: ['Env']
+  Id: 2
+  Body: {
+    "name": "morpheus",
+    "job": "zion resident"
+  }
+  Code: ~
+
+request:
+  path: "{$Env.server}/users/{$Id}"
+  method: PUT
+  body: 
+    ::inject: $Body
+  return: .code
+
+spec:
+  # # can replace variable like this
+  # with:
+  #   body: {
+  #     "other": "data"
+  #   }
+  asserts:
+    - {type: AssertEquals, actual: $Code, expected: 200}

--- a/sample_specs/reqres-in-v0.7.3/UserUpdateSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserUpdateSpec.chk
@@ -1,26 +1,29 @@
-version: 'default:testcase:0.7.2'
+version: 'default:testcase:0.7.3'
 
 variables: 
-  ::import: ['Env']
+  # __import__: ['Env']
   Id: 2
   Body: {
     "name": "morpheus",
     "job": "zion resident"
   }
   Code: ~
+  ... :
+    - Env: .Env
 
 request:
   path: "{$Env.server}/users/{$Id}"
   method: PUT
-  body: 
-    ::inject: $Body
-  return: .code
+  body: $Body # inject Body here
+  all_include: 
+    ... :  # unpack statement
+      - $Body
+      - id: $Id
+    class: 1
+
+  return: 
+    - .code: $Code
 
 spec:
-  # # can replace variable like this
-  # with:
-  #   body: {
-  #     "other": "data"
-  #   }
   asserts:
     - {type: AssertEquals, actual: $Code, expected: 200}

--- a/sample_specs/reqres-in-v0.7.3/UserUpdateSpec.chk
+++ b/sample_specs/reqres-in-v0.7.3/UserUpdateSpec.chk
@@ -21,9 +21,6 @@ request:
       - id: $Id
     class: 1
 
-  return: 
-    - .code: $Code
-
 spec:
   asserts:
-    - {type: AssertEquals, actual: $Code, expected: 200}
+    - {type: AssertEquals, actual: .response.code, expected: 200}

--- a/sample_specs/reqres-in-v0.7.3/Vars.chk
+++ b/sample_specs/reqres-in-v0.7.3/Vars.chk
@@ -3,3 +3,4 @@ version: 'default:variable:0.7.3'
 variables:
   varA: GET
   varB: $ENV.SHELL
+  method: POST

--- a/sample_specs/reqres-in-v0.7.3/Vars.chk
+++ b/sample_specs/reqres-in-v0.7.3/Vars.chk
@@ -1,0 +1,6 @@
+version: 'default:variable:0.7.2'
+
+::import: [ENV]
+
+varA: GET
+varB: $ENV.SHELL

--- a/sample_specs/reqres-in-v0.7.3/Vars.chk
+++ b/sample_specs/reqres-in-v0.7.3/Vars.chk
@@ -1,6 +1,5 @@
-version: 'default:variable:0.7.2'
+version: 'default:variable:0.7.3'
 
-::import: [ENV]
-
-varA: GET
-varB: $ENV.SHELL
+variables:
+  varA: GET
+  varB: $ENV.SHELL

--- a/sample_specs/reqres-in-v0.7.3/Vars2.chk
+++ b/sample_specs/reqres-in-v0.7.3/Vars2.chk
@@ -1,0 +1,4 @@
+version: 'default:variable:0.7.2'
+
+server: 'https://reqres.in'
+varB: 20

--- a/sample_specs/reqres-in-v0.7.3/Vars2.chk
+++ b/sample_specs/reqres-in-v0.7.3/Vars2.chk
@@ -1,4 +1,5 @@
 version: 'default:variable:0.7.2'
 
-server: 'https://reqres.in'
-varB: 20
+variables:
+  server: 'https://reqres.in'
+  varB: 20


### PR DESCRIPTION
- remove `return` statement
- `describe` express what the spec does, not input marker
- example of tag e.g. `:input:` included for variables